### PR TITLE
Events changes

### DIFF
--- a/rosetta-patch-schema.json
+++ b/rosetta-patch-schema.json
@@ -56,9 +56,6 @@
         "parameters": {
           "$ref": "#/definitions/parameters"
         },
-        "returns": {
-          "$ref": "#/definitions/returns"
-        },
         "notes": {
           "type": "string"
         }

--- a/rosetta-patch-schema.json
+++ b/rosetta-patch-schema.json
@@ -50,6 +50,33 @@
       },
       "additionalProperties": false
     },
+    "hooks": {
+      "type": "object",
+      "description": "Lua Hooks.",
+      "minItems": 1,
+      "patternProperties": {
+        "^": {
+          "$ref": "#/definitions/hook"
+        }
+      },
+      "additionalProperties": false
+    },
+    "hook": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "readOnly": true
+        },
+        "callback": {
+          "$ref": "#/definitions/callback"
+        },
+        "notes": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
     "callback": {
       "type": "object",
       "properties": {

--- a/rosetta-schema.json
+++ b/rosetta-schema.json
@@ -104,6 +104,63 @@
     },
 
 
+    "hooks": {
+      "type": "object",
+      "description": "Lua Hooks.",
+      "minItems": 1,
+      "patternProperties": {
+        "^": {
+          "$ref": "#/definitions/hook"
+        }
+      },
+      "additionalProperties": false
+    },
+    "hook": {
+      "type": "object",
+      "properties": {
+        "deprecated": {
+          "type": "boolean",
+          "description": "If the hook is deprecated."
+        },
+        "name": {
+          "type": "string"
+        },
+        "callback": {
+          "$ref": "#/definitions/callback"
+        },
+        "notes": {
+          "type": "string"
+        },
+        "context": {
+          "type": "object",
+          "properties": {
+            "server": {
+              "type": "boolean",
+              "description": "If the hook fires on the server.",
+              "default": true
+            },
+            "client": {
+              "type": "boolean",
+              "description": "If the hook fires on the client.",
+              "default": true
+            },
+            "singleplayer": {
+              "type": "boolean",
+              "description": "If the hook fires in singleplayer.",
+              "default": true
+            },
+            "multiplayer": {
+              "type": "boolean",
+              "description": "If the hook fires in multiplayer.",
+              "default": true
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+
+
     "luaClasses": {
       "type": "object",
       "description": "Lua Classes.",

--- a/rosetta-schema.json
+++ b/rosetta-schema.json
@@ -100,9 +100,6 @@
           "type": "string"
         }
       },
-      "required": [
-        "returns"
-      ],
       "additionalProperties": false
     },
 

--- a/rosetta-schema.json
+++ b/rosetta-schema.json
@@ -49,6 +49,10 @@
     "event": {
       "type": "object",
       "properties": {
+        "deprecated": {
+          "type": "boolean",
+          "description": "If the event is deprecated."
+        },
         "name": {
           "type": "string"
         },
@@ -89,10 +93,6 @@
     "callback": {
       "type": "object",
       "properties": {
-        "deprecated": {
-          "type": "boolean",
-          "description": "If the callback is deprecated."
-        },
         "parameters": {
           "$ref": "#/definitions/luaParameters"
         },

--- a/rosetta-schema.json
+++ b/rosetta-schema.json
@@ -71,9 +71,6 @@
         "parameters": {
           "$ref": "#/definitions/luaParameters"
         },
-        "returns": {
-          "$ref": "#/definitions/luaReturns"
-        },
         "notes": {
           "type": "string"
         }

--- a/rosetta-schema.json
+++ b/rosetta-schema.json
@@ -57,6 +57,31 @@
         },
         "notes": {
           "type": "string"
+        },
+        "context": {
+          "type": "object",
+          "properties": {
+            "server": {
+              "type": "boolean",
+              "description": "If the event fires on the server.",
+              "default": true
+            },
+            "client": {
+              "type": "boolean",
+              "description": "If the event fires on the client.",
+              "default": true
+            },
+            "singleplayer": {
+              "type": "boolean",
+              "description": "If the event fires in singleplayer.",
+              "default": true
+            },
+            "multiplayer": {
+              "type": "boolean",
+              "description": "If the event fires in multiplayer.",
+              "default": true
+            }
+          }
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
This PR introduces changes to the schema I found necessary when updating PZEventDoc to use Rosetta:
- Added context property to event definition, dictionary of contexts where the event fires (client/server/sp/mp)
- Removed return property from callback definition - the game doesn't have any mechanism to catch callback return values
- Hook definitions added (copy paste from event definitions)
- Deprecated property is moved from callback to event