### PR TITLE
Add script/generic callbacks

### DIFF
--- a/rosetta-schema.json
+++ b/rosetta-schema.json
@@ -163,6 +163,17 @@
       "additionalProperties": false
     },
 
+    "callbacks": {
+      "type": "object",
+      "description": "Container for other callback types.",
+      "minItems": 1,
+      "patternProperties": {
+        "^": {
+          "$ref": "#/definitions/callback"
+        }
+      },
+      "additionalProperties": false
+    },
 
     "luaClasses": {
       "type": "object",

--- a/rosetta-schema.json
+++ b/rosetta-schema.json
@@ -96,6 +96,9 @@
         "parameters": {
           "$ref": "#/definitions/luaParameters"
         },
+        "returns": {
+          "$ref": "#/definitions/luaReturns"
+        },
         "notes": {
           "type": "string"
         }


### PR DESCRIPTION
Adds a return property to the callback definition (which I just removed in my previous PR X_X) and adds a callbacks list. This list is intended for functions linked to scripts (e.g. item OnEat functions) but we could dump any other function type definitions we need that don't fit other categories in there.