### PR TITLE
Add support for operators and overloads

### DIFF
--- a/1.1/lua/class.json
+++ b/1.1/lua/class.json
@@ -51,6 +51,14 @@
                 "$ref": "overload.json"
             }
         },
+        "operators": {
+            "type": "array",
+            "minItems": 1,
+            "additionalItems": false,
+            "items": {
+                "$ref": "operator.json"
+            }
+        },
         "methods": {
             "type": "array",
             "minItems": 1,

--- a/1.1/lua/class.json
+++ b/1.1/lua/class.json
@@ -43,6 +43,14 @@
                 }
             }
         },
+        "overloads": {
+            "type": "array",
+            "minItems": 1,
+            "additionalItems": false,
+            "items": {
+                "$ref": "overload.json"
+            }
+        },
         "methods": {
             "type": "array",
             "minItems": 1,

--- a/1.1/lua/method.json
+++ b/1.1/lua/method.json
@@ -26,6 +26,13 @@
                 "$ref": "return.json"
             }
         },
+        "overloads": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "$ref": "overload.json"
+            }
+        },
         "notes": {
             "type": "string"
         },

--- a/1.1/lua/operator.json
+++ b/1.1/lua/operator.json
@@ -1,0 +1,25 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "https://raw.githubusercontent.com/asledgehammer/PZ-Rosetta-Schema/main/1.1/lua/operator.json",
+    "type": "object",
+    "minItems": 1,
+    "additionalProperties": false,
+    "properties": {
+        "operation": {
+            "type": "string"
+        },
+        "parameter": {
+            "type": "string"
+        },
+        "return": {
+            "type": "string"
+        },
+        "tags": {
+            "$ref": "../tags.json"
+        }
+    },
+    "required": [
+        "operation",
+        "return"
+    ]
+}

--- a/1.1/lua/overload.json
+++ b/1.1/lua/overload.json
@@ -1,17 +1,10 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "https://raw.githubusercontent.com/asledgehammer/PZ-Rosetta-Schema/main/1.1/lua/function.json",
+    "$id": "https://raw.githubusercontent.com/asledgehammer/PZ-Rosetta-Schema/main/1.1/lua/overload.json",
     "type": "object",
     "minItems": 1,
     "additionalProperties": false,
     "properties": {
-        "name": {
-            "type": "string"
-        },
-        "deprecated": {
-            "type": "boolean",
-            "description": "If the function is deprecated."
-        },
         "parameters": {
             "type": "array",
             "minItems": 1,
@@ -26,21 +19,11 @@
                 "$ref": "return.json"
             }
         },
-        "overloads": {
-            "type": "array",
-            "minItems": 1,
-            "items": {
-                "$ref": "overload.json"
-            }
-        },
         "notes": {
             "type": "string"
         },
         "tags": {
             "$ref": "../tags.json"
         }
-    },
-    "required": [
-        "name"
-    ]
+    }
 }

--- a/1.1/lua/table.json
+++ b/1.1/lua/table.json
@@ -29,6 +29,14 @@
                 "$ref": "method.json"
             }
         },
+        "overloads": {
+            "type": "array",
+            "minItems": 1,
+            "additionalItems": false,
+            "items": {
+                "$ref": "overload.json"
+            }
+        },
         "notes": {
             "type": "string"
         },

--- a/1.1/lua/table.json
+++ b/1.1/lua/table.json
@@ -37,6 +37,14 @@
                 "$ref": "overload.json"
             }
         },
+        "operators": {
+            "type": "array",
+            "minItems": 1,
+            "additionalItems": false,
+            "items": {
+                "$ref": "operator.json"
+            }
+        },
         "notes": {
             "type": "string"
         },


### PR DESCRIPTION
- Added an `overloads` field to various objects. For tables and classes, this is the recommended way to document `__call` metamethods; see [`@overload`](https://luals.github.io/wiki/annotations/#overload).
- Added an `operators` field to classes and tables, to support the [`@operator`](https://luals.github.io/wiki/annotations/#operator) annotation.