### PR TITLE
Add generics support for Lua

### DIFF
--- a/1.2/lua/class.json
+++ b/1.2/lua/class.json
@@ -63,6 +63,13 @@
                 "$ref": "operator.json"
             }
         },
+        "generics": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "$ref": "generic.json"
+            }
+        },
         "methods": {
             "type": "array",
             "minItems": 1,

--- a/1.2/lua/constructor.json
+++ b/1.2/lua/constructor.json
@@ -16,6 +16,13 @@
                 "$ref": "parameter.json"
             }
         },
+        "generics": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "$ref": "generic.json"
+            }
+        },
         "notes": {
             "type": "string"
         }

--- a/1.2/lua/function.json
+++ b/1.2/lua/function.json
@@ -33,6 +33,13 @@
                 "$ref": "overload.json"
             }
         },
+        "generics": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "$ref": "generic.json"
+            }
+        },
         "notes": {
             "type": "string"
         },

--- a/1.2/lua/generic.json
+++ b/1.2/lua/generic.json
@@ -1,0 +1,21 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "https://raw.githubusercontent.com/asledgehammer/PZ-Rosetta-Schema/main/1.1/lua/generic.json",
+    "type": "object",
+    "minItems": 1,
+    "additionalProperties": false,
+    "properties": {
+        "name": {
+            "type": "string"
+        },
+        "extends": {
+            "type": "string"
+        },
+        "tags": {
+            "$ref": "../tags.json"
+        }
+    },
+    "required": [
+        "name"
+    ]
+}

--- a/1.2/lua/method.json
+++ b/1.2/lua/method.json
@@ -33,6 +33,13 @@
                 "$ref": "overload.json"
             }
         },
+        "generics": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "$ref": "generic.json"
+            }
+        },
         "notes": {
             "type": "string"
         },


### PR DESCRIPTION
Added `generics` property to `class`, `constructor`, `function`, and `method`, to support the [@generic](https://luals.github.io/wiki/annotations/#generic) tag.