### PR TITLE
Fix 1.1 schemas referencing

### DIFF
--- a/1.1.json
+++ b/1.1.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "https://raw.githubusercontent.com/Rosetta-Docs/Rosetta-Docs-Schema/refs/heads/1.1/1.1/1.1.json",
+    "$id": "1.1.json",
     "type": "object",
     "minProperties": 1,
     "additionalItems": true,
@@ -24,7 +24,7 @@
             "type": "object",
             "properties": {
                 "projectzomboid": {
-                    "$ref": "https://raw.githubusercontent.com/Rosetta-Docs/Rosetta-Docs-Schema/refs/heads/1.1/1.1/game/projectzomboid.json"
+                    "$ref": "1.1/game/projectzomboid.json"
                 }
             }
         },

--- a/1.1/game/projectzomboid.json
+++ b/1.1/game/projectzomboid.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "https://raw.githubusercontent.com/Rosetta-Docs/Rosetta-Docs-Schema/refs/heads/1.1/1.1/game/projectzomboid.json",
+    "$id": "game/projectzomboid.json",
     "type": "object",
     "minItems": 1,
     "properties": {
@@ -18,7 +18,7 @@
                             "minItems": 1,
                             "additionalItems": false,
                             "items": {
-                                "$ref": "https://raw.githubusercontent.com/Rosetta-Docs/Rosetta-Docs-Schema/refs/heads/1.1/1.1/game/projectzomboid/event.json"
+                                "$ref": "projectzomboid/event.json"
                             }
                         }
                     }

--- a/1.1/game/projectzomboid/context.json
+++ b/1.1/game/projectzomboid/context.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "https://raw.githubusercontent.com/Rosetta-Docs/Rosetta-Docs-Schema/refs/heads/1.1/1.1/games/projectzomboid/context.json",
+    "$id": "games/projectzomboid/context.json",
     "type": "object",
     "minItems": 1,
     "additionalProperties": false,

--- a/1.1/game/projectzomboid/event.json
+++ b/1.1/game/projectzomboid/event.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "https://raw.githubusercontent.com/Rosetta-Docs/Rosetta-Docs-Schema/refs/heads/1.1/1.1/games/projectzomboid/event.json",
+    "$id": "games/projectzomboid/event.json",
     "type": "object",
     "minItems": 1,
     "additionalProperties": false,

--- a/1.1/java.json
+++ b/1.1/java.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "https://raw.githubusercontent.com/Rosetta-Docs/Rosetta-Docs-Schema/refs/heads/1.1/1.1/java",
+    "$id": "java",
     "type": "object",
     "additionalProperties": false,
     "properties": {
@@ -9,7 +9,7 @@
             "minItems": 1,
             "patternProperties": {
                 "^": {
-                    "$ref": "https://raw.githubusercontent.com/Rosetta-Docs/Rosetta-Docs-Schema/refs/heads/1.1/1.1/java/package.json"
+                    "$ref": "java/package.json"
                 }
             }
         },
@@ -18,7 +18,7 @@
             "minItems": 1,
             "additionalItems": false,
             "items": {
-                "$ref": "https://raw.githubusercontent.com/Rosetta-Docs/Rosetta-Docs-Schema/refs/heads/1.1/1.1/java/method.json"
+                "$ref": "java/method.json"
             }
         }
     }

--- a/1.1/java/class.json
+++ b/1.1/java/class.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "https://raw.githubusercontent.com/Rosetta-Docs/Rosetta-Docs-Schema/refs/heads/1.1/1.1/java/class.json",
+    "$id": "java/class.json",
     "type": "object",
     "minItems": 1,
     "additionalProperties": false,

--- a/1.1/java/constructor.json
+++ b/1.1/java/constructor.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "https://raw.githubusercontent.com/Rosetta-Docs/Rosetta-Docs-Schema/refs/heads/1.1/1.1/java/constructor.json",
+    "$id": "java/constructor.json",
     "type": "object",
     "minItems": 1,
     "additionalProperties": false,

--- a/1.1/java/field.json
+++ b/1.1/java/field.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "https://raw.githubusercontent.com/Rosetta-Docs/Rosetta-Docs-Schema/refs/heads/1.1/1.1/java/field.json",
+    "$id": "java/field.json",
     "type": "object",
     "minItems": 1,
     "additionalProperties": false,

--- a/1.1/java/generics.json
+++ b/1.1/java/generics.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "https://raw.githubusercontent.com/Rosetta-Docs/Rosetta-Docs-Schema/refs/heads/1.1/1.1/java/generics.json",
+    "$id": "java/generics.json",
     "minItems": 1,
     "type": "array",
     "additionalItems": false,

--- a/1.1/java/method.json
+++ b/1.1/java/method.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "https://raw.githubusercontent.com/Rosetta-Docs/Rosetta-Docs-Schema/refs/heads/1.1/1.1/java/method.json",
+    "$id": "java/method.json",
     "type": "object",
     "additionalProperties": false,
     "properties": {

--- a/1.1/java/modifiers.json
+++ b/1.1/java/modifiers.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "https://raw.githubusercontent.com/Rosetta-Docs/Rosetta-Docs-Schema/refs/heads/1.1/1.1/java/modifiers.json",
+    "$id": "java/modifiers.json",
     "type": "array",
     "minItems": 1,
     "additionalItems": false,

--- a/1.1/java/package.json
+++ b/1.1/java/package.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "https://raw.githubusercontent.com/Rosetta-Docs/Rosetta-Docs-Schema/refs/heads/1.1/1.1/java/package.json",
+    "$id": "java/package.json",
     "type": "object",
     "minItems": 1,
     "additionalProperties": false,

--- a/1.1/java/parameter.json
+++ b/1.1/java/parameter.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "https://raw.githubusercontent.com/Rosetta-Docs/Rosetta-Docs-Schema/refs/heads/1.1/1.1/java/parameter.json",
+    "$id": "java/parameter.json",
     "type": "object",
     "additionalProperties": false,
     "properties": {

--- a/1.1/java/return.json
+++ b/1.1/java/return.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "https://raw.githubusercontent.com/Rosetta-Docs/Rosetta-Docs-Schema/refs/heads/1.1/1.1/java/return.json",
+    "$id": "java/return.json",
     "type": "object",
     "additionalProperties": false,
     "properties": {

--- a/1.1/java/type.json
+++ b/1.1/java/type.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "https://raw.githubusercontent.com/Rosetta-Docs/Rosetta-Docs-Schema/refs/heads/1.1/1.1/java/type.json",
+    "$id": "java/type.json",
     "type": "object",
     "minItems": 1,
     "additionalProperties": false,

--- a/1.1/lua.json
+++ b/1.1/lua.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "https://raw.githubusercontent.com/Rosetta-Docs/Rosetta-Docs-Schema/refs/heads/1.1/1.1/lua.json",
+    "$id": "lua.json",
     "type": "object",
     "additionalItems": false,
     "properties": {
@@ -12,7 +12,7 @@
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "$ref": "https://raw.githubusercontent.com/Rosetta-Docs/Rosetta-Docs-Schema/refs/heads/1.1/1.1/lua/alias.json"
+                        "$ref": "lua/alias.json"
                     }
                 }
             }
@@ -23,7 +23,7 @@
             "additionalProperties": false,
             "patternProperties": {
                 "^": {
-                    "$ref": "https://raw.githubusercontent.com/Rosetta-Docs/Rosetta-Docs-Schema/refs/heads/1.1/1.1/lua/class.json"
+                    "$ref": "lua/class.json"
                 }
             }
         },
@@ -33,7 +33,7 @@
             "additionalProperties": false,
             "patternProperties": {
                 "^": {
-                    "$ref": "https://raw.githubusercontent.com/Rosetta-Docs/Rosetta-Docs-Schema/refs/heads/1.1/1.1/lua/table.json"
+                    "$ref": "lua/table.json"
                 }
             }
         },
@@ -42,7 +42,7 @@
             "minItems": 1,
             "additionalItems": false,
             "items": {
-                "$ref": "https://raw.githubusercontent.com/Rosetta-Docs/Rosetta-Docs-Schema/refs/heads/1.1/1.1/lua/function.json"
+                "$ref": "lua/function.json"
             }
         },
         "fields": {
@@ -51,7 +51,7 @@
             "additionalProperties": false,
             "patternProperties": {
                 "^": {
-                    "$ref": "https://raw.githubusercontent.com/Rosetta-Docs/Rosetta-Docs-Schema/refs/heads/1.1/1.1/lua/field.json"
+                    "$ref": "lua/field.json"
                 }
             }
         }

--- a/1.1/lua/alias.json
+++ b/1.1/lua/alias.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "https://raw.githubusercontent.com/Rosetta-Docs/Rosetta-Docs-Schema/refs/heads/1.1/1.1/lua/alias.json",
+    "$id": "lua/alias.json",
     "type": "object",
     "minItems": 1,
     "additionalProperties": false,

--- a/1.1/lua/callback.json
+++ b/1.1/lua/callback.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "https://raw.githubusercontent.com/Rosetta-Docs/Rosetta-Docs-Schema/refs/heads/1.1/1.1/lua/callback.json",
+    "$id": "lua/callback.json",
     "type": "object",
     "minItems": 1,
     "additionalProperties": false,

--- a/1.1/lua/class.json
+++ b/1.1/lua/class.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "https://raw.githubusercontent.com/Rosetta-Docs/Rosetta-Docs-Schema/refs/heads/1.1/1.1/lua/class.json",
+    "$id": "lua/class.json",
     "type": "object",
     "minItems": 1,
     "additionalProperties": false,

--- a/1.1/lua/constructor.json
+++ b/1.1/lua/constructor.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "https://raw.githubusercontent.com/Rosetta-Docs/Rosetta-Docs-Schema/refs/heads/1.1/1.1/lua/constructor.json",
+    "$id": "lua/constructor.json",
     "type": "object",
     "minItems": 1,
     "additionalProperties": false,

--- a/1.1/lua/field.json
+++ b/1.1/lua/field.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "https://raw.githubusercontent.com/Rosetta-Docs/Rosetta-Docs-Schema/refs/heads/1.1/1.1/lua/field.json",
+    "$id": "lua/field.json",
     "type": "object",
     "minItems": 1,
     "additionalProperties": false,

--- a/1.1/lua/function.json
+++ b/1.1/lua/function.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "https://raw.githubusercontent.com/Rosetta-Docs/Rosetta-Docs-Schema/refs/heads/1.1/1.1/lua/function.json",
+    "$id": "lua/function.json",
     "type": "object",
     "minItems": 1,
     "additionalProperties": false,

--- a/1.1/lua/method.json
+++ b/1.1/lua/method.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "https://raw.githubusercontent.com/Rosetta-Docs/Rosetta-Docs-Schema/refs/heads/1.1/1.1/lua/method.json",
+    "$id": "lua/method.json",
     "type": "object",
     "minItems": 1,
     "additionalProperties": false,

--- a/1.1/lua/operator.json
+++ b/1.1/lua/operator.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "https://raw.githubusercontent.com/Rosetta-Docs/Rosetta-Docs-Schema/refs/heads/1.1/1.1/lua/operator.json",
+    "$id": "lua/operator.json",
     "type": "object",
     "minItems": 1,
     "additionalProperties": false,

--- a/1.1/lua/overload.json
+++ b/1.1/lua/overload.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "https://raw.githubusercontent.com/Rosetta-Docs/Rosetta-Docs-Schema/refs/heads/1.1/1.1/lua/overload.json",
+    "$id": "lua/overload.json",
     "type": "object",
     "minItems": 1,
     "additionalProperties": false,

--- a/1.1/lua/parameter.json
+++ b/1.1/lua/parameter.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "https://raw.githubusercontent.com/Rosetta-Docs/Rosetta-Docs-Schema/refs/heads/1.1/1.1/lua/parameter.json",
+    "$id": "lua/parameter.json",
     "type": "object",
     "minItems": 1,
     "additionalProperties": false,

--- a/1.1/lua/return.json
+++ b/1.1/lua/return.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "https://raw.githubusercontent.com/Rosetta-Docs/Rosetta-Docs-Schema/refs/heads/1.1/1.1/lua/return.json",
+    "$id": "lua/return.json",
     "type": "object",
     "minItems": 1,
     "additionalProperties": false,

--- a/1.1/lua/table.json
+++ b/1.1/lua/table.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "https://raw.githubusercontent.com/Rosetta-Docs/Rosetta-Docs-Schema/refs/heads/1.1/1.1/lua/table.json",
+    "$id": "lua/table.json",
     "type": "object",
     "minItems": 1,
     "additionalProperties": false,

--- a/1.1/tags.json
+++ b/1.1/tags.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "https://raw.githubusercontent.com/Rosetta-Docs/Rosetta-Docs-Schema/refs/heads/1.1/1.1/tags.json",
+    "$id": "tags.json",
     "type": "array",
     "minItems": 1,
     "additionalItems": false,

--- a/examples/1.1.json
+++ b/examples/1.1.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://raw.githubusercontent.com/Rosetta-Docs/Rosetta-Docs-Schema/refs/heads/1.1/1.1.json?p=2",
+    "$schema": "../1.1.json",
     "version": "1.1",
     "languages": {
         "lua": {


### PR DESCRIPTION
Fix schemas to use relative references instead of raw github links references for better stability

Motivation:
> Problems loading reference 'https://raw.githubusercontent.com/Rosetta-Docs/Rosetta-Docs-Schema/refs/heads/1.1/1.1/1.1/tags.json': Unable to load schema from 'https://raw.githubusercontent.com/Rosetta-Docs/Rosetta-Docs-Schema/refs/heads/1.1/1.1/1.1/tags.json': No content.YAML(65536)

What was done:
- remove any raw github files references so references properly use relative referencing from the currently loaded schema (caused issues where it wouldn't properly link to the right paths, should be more stable now and easier to debug)
- renamed the IDs to the file names relative to root
- tested by linking to 1.1.json raw github link